### PR TITLE
npm3: referencing relative node_modules directory is a no no

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elderissuesdresser-pack",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -4,9 +4,9 @@ require('!file?name=[name].[ext]!../static/index.html');
 require('./static.js');
 
 // load and apply css
-require('../node_modules/bootstrap/dist/css/bootstrap.min.css');
-require('../node_modules/bootstrap-arrow-buttons/dist/' +
-        'css/bootstrap-arrow-buttons.css');
+require('!style!css!bootstrap/dist/css/bootstrap.min.css');
+require('!style!css!bootstrap-arrow-buttons/dist/css/' +
+        'bootstrap-arrow-buttons.css');
 require('../static/css/common.css');
 require('../static/css/infographic.css');
 


### PR DESCRIPTION
[npm3 resolves dependencies differently than npm2](https://docs.npmjs.com/how-npm-works/npm3)

The relative referencing I've been using is fine in npm2. Updating to use a more correct syntax that works for both.