### PR TITLE
Fix image loading

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,13 +23,23 @@ module.exports = {
             {
                 test: /\.(png|svg|jpg|gif)$/,
                 use: [
-                    'file-loader'
+                    {
+                        loader: 'file-loader',
+                        options: {
+                            esModule: false
+                        }
+                    }
                 ]
             },
             {
                 test: /\.(woff|woff2|eot|ttf|otf)$/,
                 use: [
-                    'file-loader'
+                    {
+                        loader: 'file-loader',
+                        options: {
+                            esModule: false
+                        }
+                    }
                 ]
             }
         ]


### PR DESCRIPTION
file-loader 5.0.0 turned on the option to generate ES modules by default.
Turning this option off for the moment until we have more time to investigate.

https://github.com/webpack-contrib/file-loader/pull/340/files